### PR TITLE
Should maxlevel actually be negative?

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func runChecks(ctx context.Context, w io.Writer, cf *Config) int {
 	fmt.Fprintf(w, "\nYour YOLO score: %d out of %d (%d%%)\n", score, maxScore, perc)
 	personality(w, perc)
 
-	fmt.Fprintf(w, "\nYour YOLO compliance level: %d\n", maxLevel)
+	fmt.Fprintf(w, "\nYour YOLO compliance level: %d\n", -maxLevel)
 
 	badge(w, maxLevel)
 


### PR DESCRIPTION
Should the maxlevel be negative to be consistent with the blog, i.e. negative YOLO levels? Will this change have other effects? Feel free to just close this issue if I am missing something.